### PR TITLE
Agent-centric routing

### DIFF
--- a/frontend/src/containers/SideNav/AgentNav.js
+++ b/frontend/src/containers/SideNav/AgentNav.js
@@ -9,7 +9,10 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
 import Queue from '@material-ui/icons/Queue';
 import { connect } from 'react-redux';
-import { setCurrentAgent } from 'Redux/agents/actions';
+import {
+  setCurrentAgent,
+  setCurrentAgent as actionSetCurrentAgent
+} from 'Redux/agents/actions';
 
 const styles = theme => ({
   root: {
@@ -28,23 +31,16 @@ const styles = theme => ({
 });
 
 class AgentNavs extends Component {
-  state = {
-    agentID: 0
-  };
-
-  handleChange = e => {
-    this.setState({
-      [e.target.name]: [e.target.value]
-    });
-  };
-
   handleChangeAgent = e => {
-    this.handleChange(e);
-    this.props.setAgent(this.props.history, e.target.value);
+    const agentID = e.target.value;
+    if (agentID !== -1) {
+      this.props.history.push(`/agent/${agentID}/domains`);
+      this.props.setCurrentAgent(this.props.history, agentID);
+    }
   };
 
   render () {
-    const { classes, agents } = this.props;
+    const { classes, agents, currentAgentId } = this.props;
     return (
       <div className={classes.root}>
         <TextField
@@ -53,16 +49,16 @@ class AgentNavs extends Component {
           name="agentID"
           label="Agent"
           className={classes.textField}
-          value={this.state.agentID}
+          value={currentAgentId || -1}
           onChange={this.handleChangeAgent}
           SelectProps={{
             MenuProps: {
               className: classes.menu
             }
           }}
-          // margin="normal"
           variant="outlined"
         >
+          <MenuItem value={-1}>None</MenuItem>
           {agents.map(option => (
             <MenuItem key={option._id} value={option._id}>
               {option.agentName}
@@ -97,6 +93,9 @@ const mapDispatchToProps = function (dispatch) {
   return {
     setAgent: function (history, id) {
       dispatch(setCurrentAgent(history, id));
+    },
+    setCurrentAgent: (history, id) => {
+      dispatch(actionSetCurrentAgent(history, id));
     }
   };
 };
@@ -105,7 +104,9 @@ AgentNavs.propTypes = {
   classes: PropTypes.object.isRequired,
   agents: PropTypes.array,
   setAgent: PropTypes.func,
-  history: PropTypes.object
+  history: PropTypes.object,
+  currentAgentId: PropTypes.string,
+  setCurrentAgent: PropTypes.func
 };
 
 export default withRouter(

--- a/frontend/src/containers/SideNav/ListNavs.js
+++ b/frontend/src/containers/SideNav/ListNavs.js
@@ -5,13 +5,25 @@ import ListItemText from '@material-ui/core/ListItemText';
 import List from '@material-ui/icons/List';
 import { NavLink } from 'react-router-dom';
 
-const listNavs = [
-  { title: 'Domains', link: '/domains', icon: <List /> },
-  { title: 'Intents', link: '/intents', icon: <List /> },
-  { title: 'Entitys', link: '/entities', icon: <List /> }
-];
+function ListNavs ({ currentAgentId }) {
+  const listNavs = [
+    {
+      title: 'Domains',
+      link: `/agent/${currentAgentId}/domains`,
+      icon: <List />
+    },
+    {
+      title: 'Intents',
+      link: `/agent/${currentAgentId}/intents`,
+      icon: <List />
+    },
+    {
+      title: 'Entitys',
+      link: `/agent/${currentAgentId}/entities`,
+      icon: <List />
+    }
+  ];
 
-function ListNavs (props) {
   return listNavs.map((item, key) => (
     <NavLink
       to={item.link}

--- a/frontend/src/containers/SideNav/index.js
+++ b/frontend/src/containers/SideNav/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
@@ -53,7 +53,7 @@ class SideNav extends React.Component {
   };
 
   render () {
-    const { classes, theme } = this.props;
+    const { classes, theme, currentAgentId } = this.props;
 
     const drawer = (
       <div>
@@ -62,9 +62,13 @@ class SideNav extends React.Component {
         {/* </div> */}
         <Divider />
         <List>
-          <AgentNav />
-          <Divider />
-          <ListNavs />
+          <AgentNav currentAgentId={currentAgentId} />
+          {currentAgentId && (
+            <Fragment>
+              <Divider />
+              <ListNavs currentAgentId={currentAgentId}/>
+            </Fragment>
+          )}
         </List>
         <Divider />
       </div>
@@ -107,7 +111,8 @@ class SideNav extends React.Component {
 
 const mapStateToProps = reduxState => {
   return {
-    isOpen: reduxState.navs.sideBarIsOpen
+    isOpen: reduxState.navs.sideBarIsOpen,
+    currentAgentId: reduxState.agents.currentAgent._id
   };
 };
 
@@ -124,7 +129,8 @@ SideNav.propTypes = {
   container: PropTypes.object,
   theme: PropTypes.object.isRequired,
   isOpen: PropTypes.bool,
-  setIsOpen: PropTypes.func.isRequired
+  setIsOpen: PropTypes.func.isRequired,
+  currentAgentId: PropTypes.string
 };
 
 export default connect(

--- a/frontend/src/routes/agentRouter.js
+++ b/frontend/src/routes/agentRouter.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Route, withRouter, Switch, Redirect } from 'react-router-dom';
+import domains from './domains';
+import intents from './intents';
+import { setCurrentAgent as actionSetCurrentAgent } from 'Redux/agents/actions';
+import { connect } from 'react-redux';
+
+class AgentRouter extends Component {
+  handleSetCurrentAgent (id) {
+    // TODO: Check if current agent is set to id. If not, set it
+  }
+
+  render () {
+    // TODO:
+    const { match } = this.props;
+    const { id } = match.params;
+    if (id) this.handleSetCurrentAgent(id);
+    return (
+      <Switch>
+        <Route path={`${match.url}/:agentID/domains`} component={domains} />
+        <Route path={`${match.url}/:agentID/intents`} component={intents} />
+        <Route path={`${match.url}/:agentID/entities`} component={domains} />
+        <Redirect to="/error/404" />
+      </Switch>
+    );
+  }
+}
+
+const mapDispatchToProps = dispatch => ({
+  setCurrentAgent: (history, id) => {
+    dispatch(actionSetCurrentAgent(history, id));
+  }
+});
+
+AgentRouter.propTypes = {
+  match: PropTypes.shape({
+    url: PropTypes.string.isRequired
+  }),
+  history: PropTypes.object,
+  setCurrentAgent: PropTypes.func
+};
+
+export default withRouter(
+  connect(
+    null,
+    mapDispatchToProps
+  )(AgentRouter)
+);

--- a/frontend/src/routes/domains/domainTable.js
+++ b/frontend/src/routes/domains/domainTable.js
@@ -21,6 +21,7 @@ class DomainTable extends Component {
       ...item,
       enabled: item.enabled ? 'Yes' : 'No'
     }));
+    console.log(this.props.match);
     return (
       <Fragment>
         <Paper className={classes.root}>
@@ -65,7 +66,7 @@ const mapDispatchToProps = function (dispatch) {
   return {
     setNavButton: function (
       buttonText = 'Create Domain',
-      buttonLink = '/domains/create'
+      buttonLink = 'domains/create'
     ) {
       dispatch(
         setTopNavProps({
@@ -89,7 +90,10 @@ DomainTable.propTypes = {
   classes: PropTypes.object.isRequired,
   rows: PropTypes.array,
   setNavButton: PropTypes.func,
-  history: PropTypes.object
+  history: PropTypes.object,
+  match: PropTypes.shape({
+    params: PropTypes.object
+  })
 };
 
 export default connect(

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Route, withRouter, Switch, Redirect } from 'react-router-dom';
-import domains from './domains';
-import intents from './intents';
 import root from './root';
 import agents from './agents';
 import { connect } from 'react-redux';
 import { getAllAgents } from 'Redux/agents/actions';
+import AgentRouter from './agentRouter';
 
 class MainApp extends Component {
   componentWillMount () {
@@ -15,14 +14,11 @@ class MainApp extends Component {
   }
 
   render () {
-    // const { match } = this.props;
     return (
       <main>
         <Switch>
           <Route path={`/agents`} component={agents} />
-          <Route path={`/domains`} component={domains} />
-          <Route path={`/intents`} component={intents} />
-          <Route path={`/entities`} component={domains} />
+          <Route path={`/agent`} component={AgentRouter} />
           <Route exact path={`/`} component={root} />
           <Redirect to="/error/404" />
         </Switch>

--- a/frontend/src/routes/intents/intentTable.js
+++ b/frontend/src/routes/intents/intentTable.js
@@ -61,7 +61,7 @@ const mapDispatchToProps = function (dispatch) {
   return {
     setNavButton: function (
       buttonText = 'Create Intent',
-      buttonLink = '/intents/create'
+      buttonLink = 'intents/create'
     ) {
       dispatch(
         setTopNavProps({


### PR DESCRIPTION
Domain, intent and entities routes is now specific to a certain agent id

Refactored routes are as followed:
DomainList - /agent/:id/domains
IntentList - /agent/:id/intents